### PR TITLE
Add race, and misc improvements

### DIFF
--- a/README
+++ b/README
@@ -60,6 +60,10 @@ CREATE TABLE users (
 	gambit int NOT NULL DEFAULT '0',
 	credence int NOT NULL DEFAULT '0',
 	credence_used int NOT NULL DEFAULT '0',
+	attack int NOT NULL DEFAULT '0',
+	defense int NOT NULL DEFAULT '0',
+	speed int NOT NULL DEFAULT '0',
+	freshness int NOT NULL DEFAULT '0',
 	race varchar(32) NOT NULL DEFAULT '',
 	time_racialability int NOT NULL DEFAULT '0',
 

--- a/README
+++ b/README
@@ -60,7 +60,8 @@ CREATE TABLE users (
 	gambit int NOT NULL DEFAULT '0',
 	credence int NOT NULL DEFAULT '0',
 	credence_used int NOT NULL DEFAULT '0',
-	id_inhabit_target varchar(128) NOT NULL DEFAULT '',
+	race varchar(32) NOT NULL DEFAULT '',
+	time_racialability int NOT NULL DEFAULT '0',
 
 	CONSTRAINT id_user_server PRIMARY KEY (id_user, id_server)
 );

--- a/client.py
+++ b/client.py
@@ -684,7 +684,19 @@ cmd_map = {
 	# ewcfg.cmd_set_gambit: ewcmd.set_gambit, #debug
 	# ewcfg.cmd_pointandlaugh: ewcmd.point_and_laugh,
 	ewcfg.cmd_prank: ewcmd.prank,
-	
+
+	# race
+	ewcfg.cmd_set_race: ewcmd.set_race,
+	ewcfg.cmd_reset_race: ewcmd.reset_race,
+	ewcfg.cmd_exist: ewcmd.exist,
+	ewcfg.cmd_ree: ewcmd.ree,
+	ewcfg.cmd_autocannibalize: ewcmd.autocannibalize,
+	ewcfg.cmd_rattle: ewcmd.rattle,
+	ewcfg.cmd_beep: ewcmd.beep,
+	ewcfg.cmd_yiff: ewcmd.yiff,
+	ewcfg.cmd_hiss: ewcmd.hiss,
+	ewcfg.cmd_jiggle: ewcmd.jiggle,
+	ewcfg.cmd_confuse: ewcmd.confuse,
 }
 
 debug = False

--- a/client.py
+++ b/client.py
@@ -687,6 +687,7 @@ cmd_map = {
 
 	# race
 	ewcfg.cmd_set_race: ewcmd.set_race,
+	ewcfg.cmd_set_race_alt1: ewcmd.set_race,
 	ewcfg.cmd_reset_race: ewcmd.reset_race,
 	ewcfg.cmd_exist: ewcmd.exist,
 	ewcfg.cmd_ree: ewcmd.ree,

--- a/ew.py
+++ b/ew.py
@@ -842,7 +842,7 @@ class EwUser:
 				# Retrieve object
 
 
-				cursor.execute("SELECT {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {} FROM users WHERE id_user = %s AND id_server = %s".format(
+				cursor.execute("SELECT {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {} FROM users WHERE id_user = %s AND id_server = %s".format(
 
 					ewcfg.col_slimes,
 					ewcfg.col_slimelevel,
@@ -893,6 +893,10 @@ class EwUser:
 					ewcfg.col_gambit,
 					ewcfg.col_credence,
 					ewcfg.col_credence_used,
+					ewcfg.col_attack,
+					ewcfg.col_defense,
+					ewcfg.col_speed,
+					ewcfg.col_freshness,
 					ewcfg.col_race,
 					ewcfg.col_time_racialability,
 				), (
@@ -952,8 +956,12 @@ class EwUser:
 					self.gambit = result[46]
 					self.credence = result[47]
 					self.credence_used = result[48]
-					self.race = result[49]
-					self.time_racialability = result[50]
+					self.attack = result[49]
+					self.defense = result[50]
+					self.speed = result[51]
+					self.freshness = result[52]
+					self.race = result[53]
+					self.time_racialability = result[54]
 				else:
 					self.poi = ewcfg.poi_id_downtown
 					self.life_state = ewcfg.life_state_juvenile
@@ -1009,7 +1017,7 @@ class EwUser:
 			self.limit_fix();
 
 			# Save the object.
-			cursor.execute("REPLACE INTO users({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}) VALUES(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)".format(
+			cursor.execute("REPLACE INTO users({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}) VALUES(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)".format(
 				ewcfg.col_id_user,
 				ewcfg.col_id_server,
 				ewcfg.col_slimes,
@@ -1062,6 +1070,10 @@ class EwUser:
 				ewcfg.col_gambit,
 				ewcfg.col_credence,
 				ewcfg.col_credence_used,
+				ewcfg.col_attack,
+				ewcfg.col_defense,
+				ewcfg.col_speed,
+				ewcfg.col_freshness,
 				ewcfg.col_race,
 				ewcfg.col_time_racialability,
 			), (
@@ -1117,6 +1129,10 @@ class EwUser:
 				self.gambit,
 				self.credence,
 				self.credence_used,
+				self.attack,
+				self.defense,
+				self.speed,
+				self.freshness,
 				self.race,
 				self.time_racialability
 			))

--- a/ew.py
+++ b/ew.py
@@ -16,7 +16,6 @@ class EwUser:
 	id_user = ""
 	id_server = ""
 	id_killer = ""
-	id_inhabit_target = ""
 
 	combatant_type = "player"
 
@@ -45,6 +44,7 @@ class EwUser:
 	splattered_slimes = 0
 	sap = 0
 	hardened_sap = 0
+	race = ""
 	
 	#SLIMERNALIA
 	festivity = 0
@@ -72,6 +72,7 @@ class EwUser:
 	time_expirpvp = 0
 	time_lastenlist = 0
 	time_lastdeath = 0
+	time_racialability = 0
 
 	apt_zone = "empty"
 	visiting = "empty"
@@ -228,7 +229,6 @@ class EwUser:
 			self.inebriation = 0
 			self.bounty = 0
 			self.time_lastdeath = time_now		
-			self.id_inhabit_target = ""
 	
 			# if self.life_state == ewcfg.life_state_shambler:
 			# 	self.degradation += 1
@@ -842,7 +842,7 @@ class EwUser:
 				# Retrieve object
 
 
-				cursor.execute("SELECT {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {} FROM users WHERE id_user = %s AND id_server = %s".format(
+				cursor.execute("SELECT {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {} FROM users WHERE id_user = %s AND id_server = %s".format(
 
 					ewcfg.col_slimes,
 					ewcfg.col_slimelevel,
@@ -893,7 +893,8 @@ class EwUser:
 					ewcfg.col_gambit,
 					ewcfg.col_credence,
 					ewcfg.col_credence_used,
-					ewcfg.col_id_inhabit_target,
+					ewcfg.col_race,
+					ewcfg.col_racial_cooldown,
 				), (
 					id_user,
 					id_server
@@ -951,7 +952,8 @@ class EwUser:
 					self.gambit = result[46]
 					self.credence = result[47]
 					self.credence_used = result[48]
-					self.id_inhabit_target = result[49]
+					self.race = result[49]
+					self.time_racialability = result[50]
 				else:
 					self.poi = ewcfg.poi_id_downtown
 					self.life_state = ewcfg.life_state_juvenile
@@ -1007,7 +1009,7 @@ class EwUser:
 			self.limit_fix();
 
 			# Save the object.
-			cursor.execute("REPLACE INTO users({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}) VALUES(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)".format(
+			cursor.execute("REPLACE INTO users({}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}) VALUES(%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)".format(
 				ewcfg.col_id_user,
 				ewcfg.col_id_server,
 				ewcfg.col_slimes,
@@ -1060,7 +1062,8 @@ class EwUser:
 				ewcfg.col_gambit,
 				ewcfg.col_credence,
 				ewcfg.col_credence_used,
-				ewcfg.col_id_inhabit_target,
+				ewcfg.col_race,
+				ewcfg.col_racial_cooldown,
 			), (
 				self.id_user,
 				self.id_server,
@@ -1114,7 +1117,8 @@ class EwUser:
 				self.gambit,
 				self.credence,
 				self.credence_used,
-				self.id_inhabit_target
+				self.race,
+				self.time_racialability
 			))
 
 			conn.commit()

--- a/ew.py
+++ b/ew.py
@@ -894,7 +894,7 @@ class EwUser:
 					ewcfg.col_credence,
 					ewcfg.col_credence_used,
 					ewcfg.col_race,
-					ewcfg.col_racial_cooldown,
+					ewcfg.col_time_racialability,
 				), (
 					id_user,
 					id_server
@@ -1063,7 +1063,7 @@ class EwUser:
 				ewcfg.col_credence,
 				ewcfg.col_credence_used,
 				ewcfg.col_race,
-				ewcfg.col_racial_cooldown,
+				ewcfg.col_time_racialability,
 			), (
 				self.id_user,
 				self.id_server,

--- a/ewapt.py
+++ b/ewapt.py
@@ -435,6 +435,7 @@ async def depart(cmd=None, isGoto = False, movecurrent=None):
 			user_data.persist()
 
 			ewutils.end_trade(user_data.id_user)
+			await user_data.move_inhabitants(id_poi = poi_dest.id_poi)	
 
 			await ewrolemgr.updateRoles(client=client, member=member_object)
 

--- a/ewcfg.py
+++ b/ewcfg.py
@@ -1736,7 +1736,6 @@ col_bought = "bought"
 # Database columns for inhabitation
 col_id_ghost = "id_ghost"
 col_id_fleshling = "id_fleshling"
-col_time_of_proposal = "time_of_proposal"
 col_empowered = "empowered"
 
 # Item type names

--- a/ewcfg.py
+++ b/ewcfg.py
@@ -942,6 +942,7 @@ cmd_canceltrade = cmd_prefix + 'canceltrade'
 
 # race
 cmd_set_race = cmd_prefix + 'setrace'
+cmd_set_race_alt1 = cmd_prefix + 'identifyas'
 cmd_reset_race = cmd_prefix + 'resetrace'
 cmd_exist = cmd_prefix + 'exist'
 cmd_ree = cmd_prefix + 'ree'
@@ -1262,6 +1263,7 @@ cd_enlist = 60
 
 cd_autocannibalize = 60 * 60 # can only eat yourself once per hour
 cd_drop_bone = 5 * 60
+cd_change_race = 24 * 60 * 60 # can only change your race once per day
 
 # PvP timer pushouts
 time_pvp_kill = 30 * 60
@@ -1584,7 +1586,7 @@ col_swear_jar = 'swear_jar'
 col_degradation = 'degradation'
 col_time_lastdeath = 'time_lastdeath'
 col_race = 'race'
-col_racial_cooldown = 'time_racialability'
+col_time_racialability = 'time_racialability'
 
 #SLIMERNALIA
 col_festivity = 'festivity'
@@ -2348,6 +2350,12 @@ item_list = [
 		str_name = "Brown Dye",
 		str_desc = "A small vial of brown dye.",
 		acquisition = acquisition_smelting,
+	),
+	EwGeneralItem(
+		id_item = "bone",
+		str_name = "Bone",
+		str_desc = "A small nondescript bone. Traces of fresh slime in it indicate it must've belonged to one of the city's recidents.",
+		context = 'player_bone',
 	),
 	EwGeneralItem(
 		id_item = item_id_tradingcardpack,
@@ -17597,7 +17605,7 @@ races = {
 	'furry': 'furry',
 	'scalie': 'scalie',
 	'slime-derived': 'slime-derived',
-	'abomination': 'abomination'
+	'other': 'other'
 }
 
 # lists of all the discord server objects served by bot, identified by the server id

--- a/ewcfg.py
+++ b/ewcfg.py
@@ -940,6 +940,19 @@ cmd_remove_offer = cmd_prefix + 'removeoffer'
 cmd_completetrade = cmd_prefix + 'completetrade'
 cmd_canceltrade = cmd_prefix + 'canceltrade'
 
+# race
+cmd_set_race = cmd_prefix + 'setrace'
+cmd_reset_race = cmd_prefix + 'resetrace'
+cmd_exist = cmd_prefix + 'exist'
+cmd_ree = cmd_prefix + 'ree'
+cmd_autocannibalize = cmd_prefix + 'autocannibalize'
+cmd_rattle = cmd_prefix + 'rattle'
+cmd_beep = cmd_prefix + 'beep'
+cmd_yiff = cmd_prefix + 'yiff'
+cmd_hiss = cmd_prefix + 'hiss'
+cmd_jiggle = cmd_prefix + 'jiggle'
+cmd_confuse = cmd_prefix + 'confuse'
+
 #SLIMERNALIA
 cmd_festivity = cmd_prefix + 'festivity'
 
@@ -1246,6 +1259,9 @@ cd_slimeoiddefeated = 300
 cd_scavenge = 0
 soft_cd_scavenge = 15 # Soft cooldown on scavenging
 cd_enlist = 60
+
+cd_autocannibalize = 60 * 60 # can only eat yourself once per hour
+cd_drop_bone = 5 * 60
 
 # PvP timer pushouts
 time_pvp_kill = 30 * 60
@@ -1567,7 +1583,8 @@ col_manuscript = "manuscript"
 col_swear_jar = 'swear_jar'
 col_degradation = 'degradation'
 col_time_lastdeath = 'time_lastdeath'
-col_id_inhabit_target = 'id_inhabit_target'
+col_race = 'race'
+col_racial_cooldown = 'time_racialability'
 
 #SLIMERNALIA
 col_festivity = 'festivity'
@@ -17570,6 +17587,18 @@ captcha_dict = [
 	'DIREAPPLES', 'BLACKLIMES', 'POKETUBERS', 'PULPGOURDS', 'ROWDDISHES',
 	'DRAGONCLAW',
 ]
+
+races = {
+	'humanoid': 'humanoid',
+	'amphibian': 'amphibian',
+	'food': 'food',
+	'skeleton': 'skeleton',
+	'robot': 'robot',
+	'furry': 'furry',
+	'scalie': 'scalie',
+	'slime-derived': 'slime-derived',
+	'abomination': 'abomination'
+}
 
 # lists of all the discord server objects served by bot, identified by the server id
 server_list = {}

--- a/ewcmd.py
+++ b/ewcmd.py
@@ -14,6 +14,7 @@ import ewslimeoid
 import ewfaction
 import ewapt
 import ewprank
+import ewcmd
 
 from ew import EwUser
 from ewmarket import EwMarket
@@ -364,12 +365,35 @@ async def data(cmd):
 			response = "You find yourself {} {}. ".format(poi.str_in, poi.str_name)
 
 		# return my data
+		race_suffix = race_prefix = ""
+		if user_data.race == ewcfg.races["humanoid"]:
+			race_prefix = "lame-ass "
+			race_suffix = "basic bitch "
+		elif user_data.race == ewcfg.races["amphibian"]:
+			race_prefix = "slimy "
+			race_suffix = "amphibious "
+		elif user_data.race == ewcfg.races["food"]:
+			race_suffix= "edible "
+		elif user_data.race == ewcfg.races["skeleton"]:
+			race_suffix = "skele"
+		elif user_data.race == ewcfg.races["robot"]:
+			race_prefix = "silicon-based "
+			race_suffix = "robo"
+		elif user_data.race == ewcfg.races["furry"]:
+			race_prefix = "furry "
+		elif user_data.race == ewcfg.races["scalie"]:
+			race_prefix = "scaly "
+		elif user_data.race == ewcfg.races["slime-derived"]:
+			race_prefix = "goopy "
+		elif user_data.race == ewcfg.races["other"]:
+			race_prefix = "peculiar "
+
 		if user_data.life_state == ewcfg.life_state_corpse:
-			response += "You are a level {} deadboi.".format(user_data.slimelevel)
+			response += "You are a {}level {} {}deadboi.".format(race_prefix, user_data.slimelevel, race_suffix)
 		elif user_data.life_state == ewcfg.life_state_shambler:
-			response += "You are a level {} shambler.".format(user_data.slimelevel)
+			response += "You are a {}level {} {}shambler.".format(race_prefix, user_data.slimelevel, race_suffix)
 		else:
-			response += "You are a level {} slimeboi.".format(user_data.slimelevel)
+			response += "You are a {}level {} {}slimeboi.".format(race_prefix, user_data.slimelevel, race_suffix)
 			if user_data.degradation < 20:
 				pass
 			elif user_data.degradation < 40:
@@ -385,25 +409,6 @@ async def data(cmd):
 
 		if user_data.has_soul == 0:
 			response += " You have no soul."
-
-		if user_data.race == ewcfg.races["humanoid"]:
-			response += " You are officially recognized as a boring humanoid."
-		elif user_data.race == ewcfg.races["amphibian"]:
-			response += " You are officially recognized as some denomination of amphibian."
-		elif user_data.race == ewcfg.races["food"]:
-			response += " You are officially recognized as a member of the food race."
-		elif user_data.race == ewcfg.races["skeleton"]:
-			response += " You are officially recognized as a skeleton."
-		elif user_data.race == ewcfg.races["robot"]:
-			response += " You are officially recognized as a robot."
-		elif user_data.race == ewcfg.races["furry"]:
-			response += " You are officially recognized as a filthy furry."
-		elif user_data.race == ewcfg.races["scalie"]:
-			response += " You are officially recognized as a scalie."
-		elif user_data.race == ewcfg.races["slime-derived"]:
-			response += " You are officially recognized as some kind of slime-derived lifeform."
-		elif user_data.race == ewcfg.races["abomination"]:
-			response +=" You are officially recognized as mystery creature."
 
 		coinbounty = int(user_data.bounty / ewcfg.slimecoin_exchangerate)
 
@@ -2057,8 +2062,9 @@ async def prank(cmd):
 async def set_race(cmd):
 	response = ""
 	user_data = EwUser(member = cmd.message.author)
+	time_now = int(time.time())
 
-	if not user_data.race:
+	if time_now > user_data.time_racialability:
 		if len(cmd.tokens) > 1:
 			desired_race = cmd.tokens[1]
 			if desired_race in ewcfg.races.values():
@@ -2079,17 +2085,20 @@ async def set_race(cmd):
 					response = "ENDLESS WAR acknowledges you as a scalie. You may now **{}** at your enemies as a threat.".format(ewcfg.cmd_hiss)
 				elif desired_race == ewcfg.races["slime-derived"]:
 					response = "ENDLESS WAR acknowledges you as some sort of slime-derived lifeform. **{}** to your heart's content, you goopy bastard.".format(ewcfg.cmd_jiggle)
-				elif desired_race == ewcfg.races["abomination"]:
-					response = "ENDLESS WAR struggles to categorize you, and files you as an abomination. Your peculiar form can be used to **{}** those around you.".format(ewcfg.cmd_confuse)
+				elif desired_race == ewcfg.races["other"]:
+					response = 'ENDLESS WAR struggles to categorize you, and files you under "other". Your peculiar form can be used to **{}** those around you.'.format(ewcfg.cmd_confuse)
 
+				# only set the cooldown if the user is switching race, rather than setting it up for the first time
+				if user_data.race: 
+					user_data.time_racialability = time_now + ewcfg.cd_change_race
 				user_data.race = desired_race
 				user_data.persist()
 			else:
 				response = '"{}" is not an officially recognized race in NLACakaNM. Try one of the following instead: {}.'.format(desired_race, ", ".join(builtins.map(lambda race: "**{}**".format(race), ewcfg.races.values())))
 		else:
-			response = "Please select a race."
+			response = "Please select a race from the following: {}.".format(", ".join(builtins.map(lambda race: "**{}**".format(race), ewcfg.races.values())))
 	else:
-		response = "You have already defined your race."
+		response = "You have either changed your race recently, or just used your racial ability. Take a chill pill and try again in a while."
 	
 	return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))
 
@@ -2133,7 +2142,7 @@ async def ree(cmd):
 		if roll == 0:
 			response += "https://youtu.be/cBkWhkAZ9ds"
 		else:
-			response += "**R{}**".format(random.randrange(100, 1000) * "E")
+			response += "**R{}**".format(random.randrange(200, 500) * "E")
 		return await ewutils.send_message(cmd.client, cmd.message.channel, response)
 	else:
 		response = "You people are not allowed to do that."
@@ -2144,9 +2153,9 @@ async def autocannibalize(cmd):
 	response = ""
 	if user_data.race == ewcfg.races["food"]:
 		time_now = int(time.time())
-		if (time_now - user_data.time_racialability) > ewcfg.cd_autocannibalize:
+		if time_now > user_data.time_racialability:
 			response = "You give in to the the existential desire all foods have, and take a small bite out of yourself. It hurts like a bitch, but God **DAMN** you're tasty."
-			user_data.time_racialability = time_now
+			user_data.time_racialability = time_now + ewcfg.cd_autocannibalize
 			user_data.hunger = max(user_data.hunger - (user_data.get_hunger_max() * 0.01), 0)
 			user_data.change_slimes(n = -user_data.slimes * 0.001)
 			user_data.persist()
@@ -2160,24 +2169,37 @@ async def rattle(cmd):
 	user_data = EwUser(member = cmd.message.author)
 	if user_data.race == ewcfg.races["skeleton"]:
 		time_now = int(time.time())
-		if ((time_now - user_data.time_racialability) > ewcfg.cd_drop_bone) and random.randrange(20) == 0:
+		if (time_now > user_data.time_racialability) and random.randrange(10) == 0:
+			bone_item = next(i for i in ewcfg.item_list if i.context == "player_bone")
 			ewitem.item_create(
-				item_type = ewcfg.it_cosmetic,
+				item_type = ewcfg.it_item,
 				id_user = user_data.poi,
 				id_server = cmd.message.server.id,
-				item_props = {
-					'id_cosmetic': 'bone',
-					'cosmetic_name': "bone",
-					'cosmetic_desc': "A small nondescript bone. Traces of fresh slime in it indicate it must've belonged to one of the city's recidents.",
-					'adorned': 'false'
+				item_props={
+					'id_item': bone_item.id_item,
+					'context': bone_item.context,
+					'item_name': bone_item.str_name,
+					'item_desc': bone_item.str_desc,
 				}
 			)
-			user_data.time_racialability = time_now
+			user_data.time_racialability = time_now + ewcfg.cd_drop_bone
 			user_data.persist()
+
 		if cmd.mentions_count == 1:
-			response = "You rattle your bones at {}. Horrifying.".format(cmd.mentions[0].display_name)
+			responses = [
+				", sending a shiver down their spine.",
+				", who clearly does not appreciate it.",
+				". They almost faint in shock.",
+				", scaring them so bad they pee themselves a little.",
+				". **NYEEEH!**",
+				", trying to appeal to the bones deep within them.",
+				" a little bit too hard. Oof ouch owie.",
+				" so viciously they actually get offended.",
+				" in an attempt to socialize, but they don't think you should.",
+			]
+			response = "You rattle your bones at {}{}".format(cmd.mentions[0].display_name, random.choice(responses))
 		else:
-			response = "You rattle your bones as a gesture of self-care. Don't give up, skeleton!"
+			response = "You rattle your bones."
 	else:
 		response = "You people are not allowed to do that."
 	return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))
@@ -2186,14 +2208,37 @@ async def beep(cmd):
 	user_data = EwUser(member = cmd.message.author)
 	response = ""
 	if user_data.race == ewcfg.races["robot"]:
-		responses = [
-			"```c++\ni  = 0x5f3759df - ( i >> 1 );    // what the fuck?```",
-			"```01010111 01001000 01000001 01010100 00100000 01001001\n01010011 00100000 01001101 01011001 00100000 01010000\n01010101 01010010 01010000 01001111 01010011 01000101```",
-			"`414c4c2054484f5345204d4f4d454e54532057494c4c204245204c4f535420494e2054494d45204c494b4520544541525320494e205241494e`",
-			"**BOOP**",
-			"https://youtu.be/gsNaR6FRuO0",
-			"```495420574f4e27542042452041205354594c495348204d415252494147450a492043414e2754204146464f524420412043415252494147450a42555420594f55274c4c204c4f4f4b2053574545542055504f4e2054484520534541540a4f4620412042494359434c45204255494c5420464f522054574f```",
-		]
+		roll = random.randrange(20)
+		responses = []
+		if roll > 4:
+			responses = [
+				"**BEEP**",
+				"**BOOP**",
+				"**BRRRRRRT**",
+				"**CLICK CLICK**",
+				"**BZZZZT**",
+				"**WHIRRRRRRR**",
+			]
+		elif roll > 0:
+			responses = [
+				"`ERROR: 'yiff' not in function library in ewrobot.py ln 366`",
+				"`ERROR: 418 I'm a teapot`",
+				"`ERROR: list index out of range`",
+				"`ERROR: 'response' is undefined`",
+				"https://youtu.be/7nQ2oiVqKHw"
+			]
+		else:
+			resp = await ewcmd.start(cmd = cmd)
+			response = "```CRITICAL ERROR: 'life_state' NOT FOUND\nINITIATING LIFECYCLE TERMINATION SEQUENCE IN "
+			await ewutils.edit_message(cmd.client, resp, ewutils.formatMessage(cmd.message.author, response + "10 SECONDS...```"))
+			for i in range(10, 0, -1):
+				await asyncio.sleep(1)
+				await ewutils.edit_message(cmd.client, resp, ewutils.formatMessage(cmd.message.author, response + "{} SECONDS...```".format(i)))
+			await asyncio.sleep(1)
+			await ewutils.edit_message(cmd.client, resp, ewutils.formatMessage(cmd.message.author, response + "0 SECONDS...```"))
+			await asyncio.sleep(1)
+			await ewutils.edit_message(cmd.client, resp, ewutils.formatMessage(cmd.message.author, response + "0 SECONDS...\nERROR: 'reboot' not in function library in ewrobot.py ln 459```"))
+			return
 		response = random.choice(responses)
 	else:
 		response = "You people are not allowed to do that."
@@ -2209,7 +2254,16 @@ async def yiff(cmd):
 			if target_data.race == ewcfg.races["furry"]:
 				poi = ewcfg.id_to_poi.get(user_data.poi)
 				if (target_data.poi == user_data.poi) and poi.is_apartment: # low effort
-					response = "You yiff. Fill in the blanks yourself." 
+					responses = [
+						"Wow.",
+						"Mhmm.",
+						"You yiff.",
+						"Yikes.",
+						"🤮",
+						"Yup."
+						"Congratulations."
+					]
+					response = random.choice(responses)
 				else:
 					response = "Out here, in the street? What's wrong with you?"
 			else:
@@ -2229,7 +2283,8 @@ async def hiss(cmd):
 	response = ""
 	if user_data.race == ewcfg.races["scalie"]:
 		response = "*{}* lets out a piercing hiss.\n".format(cmd.message.author.display_name)
-		response += "**HI{}**".format(random.randrange(100, 1000) * "S")
+		sssss = random.randrange(200, 500) * "s" # sssssssss
+		response += "**HIS{}**".format(''.join(random.choice((str.upper, str.lower))(s) for s in sssss))
 		return await ewutils.send_message(cmd.client, cmd.message.channel, response)
 	else:
 		response = "You people are not allowed to do that."
@@ -2251,7 +2306,7 @@ async def jiggle(cmd):
 			elif target_data.life_state == ewcfg.life_state_corpse and user_data.life_state != ewcfg.life_state_corpse:
 				response = "You jiggle in fear of {}.".format(target_member.display_name)
 			elif target_data.life_state == ewcfg.life_state_kingpin:
-				response = "You jiggle in admiration of {}.".format(target_member.display_name)
+				response = "You jiggle in awe of {}.".format(target_member.display_name)
 			elif target_data.life_state == ewcfg.life_state_enlisted:
 				if target_data.faction == user_data.faction:
 					response = "You jiggle at {} as a gesture of friendship.".format(target_member.display_name)
@@ -2267,7 +2322,7 @@ async def jiggle(cmd):
 async def confuse(cmd):
 	user_data = EwUser(member = cmd.message.author)
 	response = ""
-	if user_data.race == ewcfg.races["abomination"]:
+	if user_data.race == ewcfg.races["other"]:
 		if cmd.mentions_count == 0:
 			if random.randrange(20) == 0:
 				response = "ENDLESS WAR takes a cursory glance at you. It still doesn't know what the fuck you are."
@@ -2278,7 +2333,7 @@ async def confuse(cmd):
 		if cmd.mentions_count == 1:
 			target_member = cmd.mentions[0]
 			target_data = EwUser(member = target_member)
-			if target_data.race == ewcfg.races["abomination"]:
+			if target_data.race == ewcfg.races["other"]:
 				response = "You and {} actually understand each other in a way, despite your differences.".format(target_member.display_name)
 			else:
 				responses = [

--- a/ewcmd.py
+++ b/ewcmd.py
@@ -1,6 +1,7 @@
 import random
 import asyncio
 import time
+import builtins
 
 import ewcfg
 import ewutils
@@ -229,7 +230,7 @@ def gen_data_text(
 
 		if user_kills > 0 and enemy_kills > 0:
 			response_block += "They have {:,} confirmed kills, and {:,} confirmed hunts. ".format(user_kills,
-																								  enemy_kills)
+																									enemy_kills)
 		elif user_kills > 0:
 			response_block += "They have {:,} confirmed kills. ".format(user_kills)
 		elif enemy_kills > 0:
@@ -385,6 +386,25 @@ async def data(cmd):
 		if user_data.has_soul == 0:
 			response += " You have no soul."
 
+		if user_data.race == ewcfg.races["humanoid"]:
+			response += " You are officially recognized as a boring humanoid."
+		elif user_data.race == ewcfg.races["amphibian"]:
+			response += " You are officially recognized as some denomination of amphibian."
+		elif user_data.race == ewcfg.races["food"]:
+			response += " You are officially recognized as a member of the food race."
+		elif user_data.race == ewcfg.races["skeleton"]:
+			response += " You are officially recognized as a skeleton."
+		elif user_data.race == ewcfg.races["robot"]:
+			response += " You are officially recognized as a robot."
+		elif user_data.race == ewcfg.races["furry"]:
+			response += " You are officially recognized as a filthy furry."
+		elif user_data.race == ewcfg.races["scalie"]:
+			response += " You are officially recognized as a scalie."
+		elif user_data.race == ewcfg.races["slime-derived"]:
+			response += " You are officially recognized as some kind of slime-derived lifeform."
+		elif user_data.race == ewcfg.races["abomination"]:
+			response +=" You are officially recognized as mystery creature."
+
 		coinbounty = int(user_data.bounty / ewcfg.slimecoin_exchangerate)
 
 		weapon_item = EwItem(id_item=user_data.weapon)
@@ -486,7 +506,7 @@ async def data(cmd):
 					if ghost_in_weapon:
 							response_block += "{} is also possessing your weapon. ".format(server.get_member(ghost_in_weapon[0]).display_name)
 
-  
+	
 		if user_data.swear_jar >= 500:
 			response_block += "You're going to The Underworld for the things you've said."
 		elif user_data.swear_jar >= 100:
@@ -2033,3 +2053,243 @@ async def prank(cmd):
 				break
 
 	return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage((cmd.message.author if use_mention_displayname == False else cmd.mentions[0]), response))
+
+async def set_race(cmd):
+	response = ""
+	user_data = EwUser(member = cmd.message.author)
+
+	if not user_data.race:
+		if len(cmd.tokens) > 1:
+			desired_race = cmd.tokens[1]
+			if desired_race in ewcfg.races.values():
+
+				if desired_race == ewcfg.races["humanoid"]:
+					response = "ENDLESS WAR acknowledges you as a boring humanoid. Your lame and uninspired figure allows you to do nothing but **{}**.".format(ewcfg.cmd_exist)
+				elif desired_race == ewcfg.races["amphibian"]:
+					response = "ENDLESS WAR acknowledges you as some denomination of amphibian. You may now **{}** to let the world hear your fury.".format(ewcfg.cmd_ree)
+				elif desired_race == ewcfg.races["food"]:
+					response = "ENDLESS WAR acknowledges you as a member of the food race. If you must, you may now give in to your deepest desires, and **{}**.".format(ewcfg.cmd_autocannibalize)
+				elif desired_race == ewcfg.races["skeleton"]:
+					response = "ENDLESS WAR acknowledges you as a being of bone. You may now **{}** to intimidate your enemies or soothe yourself.".format(ewcfg.cmd_rattle)
+				elif desired_race == ewcfg.races["robot"]:
+					response = '\n```python\nplayer_data.race = "robot"	#todo: change to an ID\nplayer_data.unlock_command("{}")```'.format(ewcfg.cmd_beep)
+				elif desired_race == ewcfg.races["furry"]:
+					response = "ENDLESS WAR reluctantly acknowledges you as a furry. Yes, you can **{}** now, but please do it in private.".format(ewcfg.cmd_yiff)
+				elif desired_race == ewcfg.races["scalie"]:
+					response = "ENDLESS WAR acknowledges you as a scalie. You may now **{}** at your enemies as a threat.".format(ewcfg.cmd_hiss)
+				elif desired_race == ewcfg.races["slime-derived"]:
+					response = "ENDLESS WAR acknowledges you as some sort of slime-derived lifeform. **{}** to your heart's content, you goopy bastard.".format(ewcfg.cmd_jiggle)
+				elif desired_race == ewcfg.races["abomination"]:
+					response = "ENDLESS WAR struggles to categorize you, and files you as an abomination. Your peculiar form can be used to **{}** those around you.".format(ewcfg.cmd_confuse)
+
+				user_data.race = desired_race
+				user_data.persist()
+			else:
+				response = '"{}" is not an officially recognized race in NLACakaNM. Try one of the following instead: {}.'.format(desired_race, ", ".join(builtins.map(lambda race: "**{}**".format(race), ewcfg.races.values())))
+		else:
+			response = "Please select a race."
+	else:
+		response = "You have already defined your race."
+	
+	return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))
+
+async def reset_race(cmd):
+	if ewutils.DEBUG or author.server_permissions.administrator or user_data.life_state == ewcfg.life_state_kingpin:
+		if cmd.mentions_count == 1:
+			member = cmd.mentions[0]
+			player_data = EwUser(member = member)
+			player_data.race = ""
+			player_data.persist()
+			response = "{}'s race has been reset.".format(member.display_name)
+		else:
+			response = "Please select a player."
+		return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))
+
+async def exist(cmd):
+	user_data = EwUser(member = cmd.message.author)
+	response = ""
+	if user_data.race == ewcfg.races["humanoid"]:
+		responses = [
+			"You look at the sky and wonder how the weather will be tomorrow. Maybe you'll get to see the sun for once.",
+			"You take a deep breath and reminisce about your childhood. Mom, I miss you...",
+			"You suddenly remember something funny you did with your friends many years ago, and break into a bittersweet smile. Man, those were the times.",
+			"You contemplate what to have for dinner tomorrow. If only you had someone to share it with.",
+			"You almost trip, but quickly react to avoid falling. God, I hope no one saw that.",
+			"You catch a whiff of body odour, and stealthily check if it's coming from you. Did you forget to put on deodorant this morning?",
+			"You come up with a witty reply to an argument you had last week. If only you were always this clever.",
+		]
+		response = random.choice(responses)
+	else:
+		response = "You people are not allowed to do that."
+
+	return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))
+
+async def ree(cmd):
+	user_data = EwUser(member = cmd.message.author)
+	response = ""
+	if user_data.race == ewcfg.races["amphibian"]:
+		response = "*{}* lets out a sonorous warcry.\n".format(cmd.message.author.display_name)
+		roll = random.randrange(50)
+		if roll == 0:
+			response += "https://youtu.be/cBkWhkAZ9ds"
+		else:
+			response += "**R{}**".format(random.randrange(100, 1000) * "E")
+		return await ewutils.send_message(cmd.client, cmd.message.channel, response)
+	else:
+		response = "You people are not allowed to do that."
+		return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))
+
+async def autocannibalize(cmd):
+	user_data = EwUser(member = cmd.message.author)
+	response = ""
+	if user_data.race == ewcfg.races["food"]:
+		time_now = int(time.time())
+		if (time_now - user_data.time_racialability) > ewcfg.cd_autocannibalize:
+			response = "You give in to the the existential desire all foods have, and take a small bite out of yourself. It hurts like a bitch, but God **DAMN** you're tasty."
+			user_data.time_racialability = time_now
+			user_data.hunger = max(user_data.hunger - (user_data.get_hunger_max() * 0.01), 0)
+			user_data.change_slimes(n = -user_data.slimes * 0.001)
+			user_data.persist()
+		else:
+			response = "You're too full of yourself right now, try again later."
+	else:
+		response = "You people are not allowed to do that."
+	return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))
+
+async def rattle(cmd):
+	user_data = EwUser(member = cmd.message.author)
+	if user_data.race == ewcfg.races["skeleton"]:
+		time_now = int(time.time())
+		if ((time_now - user_data.time_racialability) > ewcfg.cd_drop_bone) and random.randrange(20) == 0:
+			ewitem.item_create(
+				item_type = ewcfg.it_cosmetic,
+				id_user = user_data.poi,
+				id_server = cmd.message.server.id,
+				item_props = {
+					'id_cosmetic': 'bone',
+					'cosmetic_name': "bone",
+					'cosmetic_desc': "A small nondescript bone. Traces of fresh slime in it indicate it must've belonged to one of the city's recidents.",
+					'adorned': 'false'
+				}
+			)
+			user_data.time_racialability = time_now
+			user_data.persist()
+		if cmd.mentions_count == 1:
+			response = "You rattle your bones at {}. Horrifying.".format(cmd.mentions[0].display_name)
+		else:
+			response = "You rattle your bones as a gesture of self-care. Don't give up, skeleton!"
+	else:
+		response = "You people are not allowed to do that."
+	return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))
+
+async def beep(cmd):
+	user_data = EwUser(member = cmd.message.author)
+	response = ""
+	if user_data.race == ewcfg.races["robot"]:
+		responses = [
+			"```c++\ni  = 0x5f3759df - ( i >> 1 );    // what the fuck?```",
+			"```01010111 01001000 01000001 01010100 00100000 01001001\n01010011 00100000 01001101 01011001 00100000 01010000\n01010101 01010010 01010000 01001111 01010011 01000101```",
+			"`414c4c2054484f5345204d4f4d454e54532057494c4c204245204c4f535420494e2054494d45204c494b4520544541525320494e205241494e`",
+			"**BOOP**",
+			"https://youtu.be/gsNaR6FRuO0",
+			"```495420574f4e27542042452041205354594c495348204d415252494147450a492043414e2754204146464f524420412043415252494147450a42555420594f55274c4c204c4f4f4b2053574545542055504f4e2054484520534541540a4f4620412042494359434c45204255494c5420464f522054574f```",
+		]
+		response = random.choice(responses)
+	else:
+		response = "You people are not allowed to do that."
+
+	return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))
+
+async def yiff(cmd):
+	user_data = EwUser(member = cmd.message.author)
+	response = ""
+	if user_data.race == ewcfg.races["furry"]:
+		if cmd.mentions_count == 1:
+			target_data = EwUser(member = cmd.mentions[0])
+			if target_data.race == ewcfg.races["furry"]:
+				poi = ewcfg.id_to_poi.get(user_data.poi)
+				if (target_data.poi == user_data.poi) and poi.is_apartment: # low effort
+					response = "You yiff. Fill in the blanks yourself." 
+				else:
+					response = "Out here, in the street? What's wrong with you?"
+			else:
+				response = "Only furries can yiff, better find another partner."
+			pass
+		elif cmd.mentions_count == 0:
+			response = "You can't yiff by yourself."
+		elif cmd.mentions_count > 1:
+			response = "The world is not prepared for a furry orgy."
+	else:
+		response = "You people are not allowed to do that."
+
+	return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))
+
+async def hiss(cmd):
+	user_data = EwUser(member = cmd.message.author)
+	response = ""
+	if user_data.race == ewcfg.races["scalie"]:
+		response = "*{}* lets out a piercing hiss.\n".format(cmd.message.author.display_name)
+		response += "**HI{}**".format(random.randrange(100, 1000) * "S")
+		return await ewutils.send_message(cmd.client, cmd.message.channel, response)
+	else:
+		response = "You people are not allowed to do that."
+		return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))
+
+async def jiggle(cmd):
+	user_data = EwUser(member = cmd.message.author)
+	response = ""
+	if user_data.race == ewcfg.races["slime-derived"]:
+		if cmd.mentions_count == 0:
+			response = "You pleasantly jiggle by yourself."
+		if cmd.mentions_count > 1:
+			response = "You jiggle at the crowd."
+		if cmd.mentions_count == 1:
+			target_member = cmd.mentions[0]
+			target_data = EwUser(member = target_member)
+			if target_data.race == ewcfg.races["slime-derived"]:
+				response = "You jiggle along with {}.".format(target_member.display_name)
+			elif target_data.life_state == ewcfg.life_state_corpse and user_data.life_state != ewcfg.life_state_corpse:
+				response = "You jiggle in fear of {}.".format(target_member.display_name)
+			elif target_data.life_state == ewcfg.life_state_kingpin:
+				response = "You jiggle in admiration of {}.".format(target_member.display_name)
+			elif target_data.life_state == ewcfg.life_state_enlisted:
+				if target_data.faction == user_data.faction:
+					response = "You jiggle at {} as a gesture of friendship.".format(target_member.display_name)
+				else:
+					response = "You jiggle at {} menacingly.".format(target_member.display_name)
+			else:
+				response = "You jiggle at {}.".format(target_member.display_name)
+	else:
+		response = "You people are not allowed to do that."
+		
+	return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))
+
+async def confuse(cmd):
+	user_data = EwUser(member = cmd.message.author)
+	response = ""
+	if user_data.race == ewcfg.races["abomination"]:
+		if cmd.mentions_count == 0:
+			if random.randrange(20) == 0:
+				response = "ENDLESS WAR takes a cursory glance at you. It still doesn't know what the fuck you are."
+			else:
+				response = "You confuse yourself. What?"
+		if cmd.mentions_count > 1:
+			response = "The crowd looks at you, winces slightly, and looks away."
+		if cmd.mentions_count == 1:
+			target_member = cmd.mentions[0]
+			target_data = EwUser(member = target_member)
+			if target_data.race == ewcfg.races["abomination"]:
+				response = "You and {} actually understand each other in a way, despite your differences.".format(target_member.display_name)
+			else:
+				responses = [
+					"{} doesn't know what on earth they're looking at.".format(target_member.display_name),
+					"{} stares at you, expressionless, then turns away.".format(target_member.display_name),
+					"{} gets a little dizzy from staring at you for too long.".format(target_member.display_name),
+					"{} wonders how you're even alive. Are you?".format(target_member.display_name),
+					"{} has seen some shit. Now they've seen some more.".format(target_member.display_name)
+				]
+				response = random.choice(responses)
+	else:
+		response = "You people are not allowed to do that."
+		
+	return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))

--- a/ewfood.py
+++ b/ewfood.py
@@ -365,10 +365,12 @@ async def order(cmd):
 
 						if target != None:
 							target_data = EwUser(member=target)
-
-						if (target_data != None) and (target_data.poi != user_data.poi):
-							response = "You can't order anything for them because they aren't here!"
-							return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))
+							if target_data.life_state == ewcfg.life_state_corpse and target_data.get_weapon_possession():
+								response = "How are you planning to feed a weapon?"
+								return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))
+							elif target_data.poi != user_data.poi:
+								response = "You can't order anything for them because they aren't here!"
+								return await ewutils.send_message(cmd.client, cmd.message.channel, ewutils.formatMessage(cmd.message.author, response))
 
 						if len(food_items) >= user_data.get_food_capacity() and target_data == None and togo:
 							# user_data never got persisted so the player won't lose money unnecessarily

--- a/ewspooky.py
+++ b/ewspooky.py
@@ -138,79 +138,84 @@ async def haunt(cmd):
 
 	if cmd.mentions_count > 1:
 		response = "You can only spook one person at a time. Who do you think you are, the Lord of Ghosts?"
-	elif cmd.mentions_count == 1:
-		# Get the user and target data from the database.
-		user_data = EwUser(member = cmd.message.author)
+	else: 
+		haunted_data = None
+		member = None
+		if cmd.mentions_count == 0:
+			haunted_data = EwUser(id_user = cmd.tokens[1], id_server = cmd.message.server.id)
+			server = ewutils.get_client().get_server(cmd.message.server.id)
+			member = server.get_member(cmd.tokens[1])
+		elif cmd.mentions_count == 1:
+			member = cmd.mentions[0]
+			haunted_data = EwUser(member = member)
+		
+		if member:
+			# Get the user and target data from the database.
+			user_data = EwUser(member = cmd.message.author)
+			market_data = EwMarket(id_server = cmd.message.server.id)
+			target_is_shambler = haunted_data.life_state == ewcfg.life_state_shambler
+			target_is_inhabitted = haunted_data.id_user == user_data.get_inhabitee()
 
-		member = cmd.mentions[0]
-		haunted_data = EwUser(member = member)
-		market_data = EwMarket(id_server = cmd.message.server.id)
-		target_is_shambler = haunted_data.life_state == ewcfg.life_state_shambler
-		target_is_inhabitted = haunted_data.id_user == user_data.get_inhabitee()
+			if user_data.life_state != ewcfg.life_state_corpse:
+				# Only dead players can haunt.
+				response = "You can't haunt now. Try {}.".format(ewcfg.cmd_suicide)
+			elif haunted_data.life_state == ewcfg.life_state_kingpin:
+				# Disallow haunting of generals.
+				response = "He is too far from the sewers in his ivory tower, and thus cannot be haunted."
+			elif (time_now - user_data.time_lasthaunt) < ewcfg.cd_haunt:
+				# Disallow haunting if the user has haunted too recently.
+				response = "You're being a little TOO spooky lately, don't you think? Try again in {} seconds.".format(int(ewcfg.cd_haunt-(time_now-user_data.time_lasthaunt)))
+			elif ewutils.channel_name_is_poi(cmd.message.channel.name) == False:
+				response = "You can't commit violence from here."
+			elif time_now > haunted_data.time_expirpvp and not (target_is_shambler or target_is_inhabitted):
+				# Require the target to be flagged for PvP
+				response = "{} is not mired in the ENDLESS WAR right now.".format(member.display_name)
+			elif haunted_data.life_state == ewcfg.life_state_corpse:
+				# Dead players can't be haunted.
+				response = "{} is already dead.".format(member.display_name)
+			elif haunted_data.life_state == ewcfg.life_state_grandfoe:
+				# Grand foes can't be haunted.
+				response = "{} is invulnerable to ghosts.".format(member.display_name)
+			elif haunted_data.life_state == ewcfg.life_state_enlisted or haunted_data.life_state == ewcfg.life_state_juvenile or haunted_data.life_state == ewcfg.life_state_shambler:
+				# Target can be haunted by the player.
+				haunted_slimes = int(haunted_data.slimes / ewcfg.slimes_hauntratio)
+				# if user_data.poi == haunted_data.poi:  # when haunting someone face to face, there is no cap and you get double the amount
+				# 	haunted_slimes *= 2
+				if haunted_slimes > ewcfg.slimes_hauntmax:
+					haunted_slimes = ewcfg.slimes_hauntmax
 
-		if user_data.life_state != ewcfg.life_state_corpse:
-			# Only dead players can haunt.
-			response = "You can't haunt now. Try {}.".format(ewcfg.cmd_suicide)
-		elif haunted_data.life_state == ewcfg.life_state_kingpin:
-			# Disallow haunting of generals.
-			response = "He is too far from the sewers in his ivory tower, and thus cannot be haunted."
-		elif (time_now - user_data.time_lasthaunt) < ewcfg.cd_haunt:
-			# Disallow haunting if the user has haunted too recently.
-			response = "You're being a little TOO spooky lately, don't you think? Try again in {} seconds.".format(int(ewcfg.cd_haunt-(time_now-user_data.time_lasthaunt)))
-		elif ewutils.channel_name_is_poi(cmd.message.channel.name) == False:
-			response = "You can't commit violence from here."
-		elif time_now > haunted_data.time_expirpvp and not (target_is_shambler or target_is_inhabitted):
-			# Require the target to be flagged for PvP
-			response = "{} is not mired in the ENDLESS WAR right now.".format(member.display_name)
-		elif haunted_data.life_state == ewcfg.life_state_corpse:
-			# Dead players can't be haunted.
-			response = "{} is already dead.".format(member.display_name)
-		elif haunted_data.life_state == ewcfg.life_state_grandfoe:
-			# Grand foes can't be haunted.
-			response = "{} is invulnerable to ghosts.".format(member.display_name)
-		elif haunted_data.life_state == ewcfg.life_state_enlisted or haunted_data.life_state == ewcfg.life_state_juvenile or haunted_data.life_state == ewcfg.life_state_shambler:
-			# Target can be haunted by the player.
-			haunted_slimes = int(haunted_data.slimes / ewcfg.slimes_hauntratio)
-			# if user_data.poi == haunted_data.poi:  # when haunting someone face to face, there is no cap and you get double the amount
-			# 	haunted_slimes *= 2
-			if haunted_slimes > ewcfg.slimes_hauntmax:
-				haunted_slimes = ewcfg.slimes_hauntmax
+				#if -user_data.slimes < haunted_slimes:  # cap on for how much you can haunt
+				#	haunted_slimes = -user_data.slimes
 
-			#if -user_data.slimes < haunted_slimes:  # cap on for how much you can haunt
-			#	haunted_slimes = -user_data.slimes
+				haunted_data.change_slimes(n = -haunted_slimes, source = ewcfg.source_haunted)
+				user_data.change_slimes(n = -haunted_slimes, source = ewcfg.source_haunter)
+				market_data.negaslime -= haunted_slimes
+				# user_data.time_lasthaunt = time_now
+				user_data.busted = False
 
-			haunted_data.change_slimes(n = -haunted_slimes, source = ewcfg.source_haunted)
-			user_data.change_slimes(n = -haunted_slimes, source = ewcfg.source_haunter)
-			market_data.negaslime -= haunted_slimes
-			user_data.time_lasthaunt = time_now
-			user_data.busted = False
+				user_data.time_expirpvp = ewutils.calculatePvpTimer(user_data.time_expirpvp, ewcfg.time_pvp_attack)
+				resp_cont.add_member_to_update(cmd.message.author)
+				# Persist changes to the database.
+				user_data.persist()
+				haunted_data.persist()
+				market_data.persist()
 
-			user_data.time_expirpvp = ewutils.calculatePvpTimer(user_data.time_expirpvp, ewcfg.time_pvp_attack)
-			resp_cont.add_member_to_update(cmd.message.author)
-			# Persist changes to the database.
-			user_data.persist()
-			haunted_data.persist()
-			market_data.persist()
+				response = "{} has been haunted by the ghost of {}! Slime has been lost!".format(member.display_name, cmd.message.author.display_name)
 
-			response = "{} has been haunted by the ghost of {}! Slime has been lost!".format(member.display_name, cmd.message.author.display_name)
-
-			haunted_channel = ewcfg.id_to_poi.get(haunted_data.poi).channel
-			haunt_message = "You feel a cold shiver run down your spine"
-			if cmd.tokens_count > 2:
-				haunt_message_content = re.sub("<.+>", "", cmd.message.content[(len(cmd.tokens[0])):]).strip()
-				# Cut down really big messages so discord doesn't crash
-				if len(haunt_message_content) > 500:
-					haunt_message_content = haunt_message_content[:-500]
-				haunt_message += " and faintly hear the words \"{}\"".format(haunt_message_content)
-			haunt_message += "."
-			haunt_message = ewutils.formatMessage(member, haunt_message)
-			resp_cont.add_channel_response(haunted_channel, haunt_message)
+				haunted_channel = ewcfg.id_to_poi.get(haunted_data.poi).channel
+				haunt_message = "You feel a cold shiver run down your spine"
+				if cmd.tokens_count > 2:
+					haunt_message_content = re.sub("<.+>" if cmd.mentions_count == 1 else "\d{17,}", "", cmd.message.content[(len(cmd.tokens[0])):]).strip()
+					# Cut down really big messages so discord doesn't crash
+					if len(haunt_message_content) > 500:
+						haunt_message_content = haunt_message_content[:-500]
+					haunt_message += " and faintly hear the words \"{}\"".format(haunt_message_content)
+				haunt_message += "."
+				haunt_message = ewutils.formatMessage(member, haunt_message)
+				resp_cont.add_channel_response(haunted_channel, haunt_message)
 		else:
-			# Some condition we didn't think of.
-			response = "You cannot haunt {}.".format(member.display_name)
-	else:
-		# No mentions, or mentions we didn't understand.
-		response = "Your spookiness is appreciated, but ENDLESS WAR didn\'t understand that name."
+			# No mentions, or mentions we didn't understand.
+			response = "Your spookiness is appreciated, but ENDLESS WAR didn\'t understand that name."
 
 	# Send the response to the player.
 	resp_cont.add_channel_response(cmd.message.channel.name, response)


### PR DESCRIPTION
To elaborate, the miscellaneous improvements are:

- Removed some vestigial code from older implementations of the ghost inhabitation mechanic that shouldn't have made it in.
- Prevent ghosts currently possessing weapons from being forcefed coleslaw (or anything else for that matter)
- Move ghosts inhabiting players out of apartments when their inhabited player departs.
- Allow ghosts to haunt via player ID in addition to via mention, as a QoL improvement for mobile players.

The race system will require updating the user table, as it adds two new columns.

I purposefully neglected to update the bot's version, as I'm not sure what the protocol for versioning is. Hit me up if you'd like me to write the patchnotes for all this.
Apologies for the shitty commits, by the way, I foolishly did everything at once and can't be bothered rebasing to keep things pristine. 